### PR TITLE
Provide better error message for an unconfigured setup

### DIFF
--- a/qcumber/config/__init__.py
+++ b/qcumber/config/__init__.py
@@ -1,5 +1,8 @@
 from os import path
 
+MISSING_MODULE_MESSAGE = '\nYou need to copy "example_module.py" files '\
+    'to module.py, and they may require customization. See the readme.'
+
 def make_path_unixy(p):
     return p.replace('\\', "/")
 

--- a/qcumber/settings.py
+++ b/qcumber/settings.py
@@ -1,7 +1,13 @@
 # Django settings for qcumber project.
 
+from qcumber.config import MISSING_MODULE_MESSAGE
+
 from qcumber.config import unixy_project_path
-import qcumber.config.current  
+
+try:
+    import qcumber.config.current
+except ImportError as e:
+    raise ImportError(MISSING_MODULE_MESSAGE)
 
 if qcumber.config.current.CONFIG == "dev":
     from qcumber.config.dev import *
@@ -18,7 +24,10 @@ django.template.add_to_builtins('django.templatetags.future')
 EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
-from qcumber.config.email_config import *
+try:
+    from qcumber.config.email_config import *
+except ImportError as e:
+    raise ImportError(MISSING_MODULE_MESSAGE)
 SERVER_EMAIL = 'server@qcumber.ca'
 SEND_BROKEN_LINK_EMAILS = True
 

--- a/qcumber/wsgi.py
+++ b/qcumber/wsgi.py
@@ -14,9 +14,13 @@ framework.
 
 """
 import os
+from qcumber.config import MISSING_MODULE_MESSAGE
 
 #Activate the virtual environment
-from virtualenv_activate import VIRTUALENV_ACTIVATE
+try:
+	from virtualenv_activate import VIRTUALENV_ACTIVATE
+except ImportError:
+    raise ImportError(MISSING_MODULE_MESSAGE)
 activate_this = VIRTUALENV_ACTIVATE
 execfile(activate_this, dict(__file__=activate_this))
 


### PR DESCRIPTION
ImportError will be raised if the example_-prefixed files have not been copied yet, with an opaque error message. This patch improves the error message and gives a hint to check the readme.
