### PR TITLE
List of courses on index is too long

### DIFF
--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -13,7 +13,24 @@ from django.template import RequestContext
 @cache_page(60 * 30)
 def index(request):
     subject_list = Subject.objects.all().order_by('abbreviation')
-    return render_to_response('course_catalog/pages/index.html', {'subject_list': subject_list})
+    numBuckets = 5
+    assert numBuckets <= 26
+
+    buckets = []
+    
+    #TODO: Buckets with semi-equal number of courses
+    perBucket = 26//numBuckets
+
+    #create letter buckets (last one takes remaining letters)
+    for x in range (0, numBuckets - 1):
+        buckets.append([chr(65 + x * perBucket) + "-" + chr(65 + (x + 1) * perBucket - 1), []])
+    buckets.append([chr(65 + (numBuckets - 1) * perBucket) + "-" + chr(90), []])
+
+    #add courses to buckets
+    for subject in subject_list:
+        buckets[int((ord(subject.abbreviation[0].upper()) - 65)/numBuckets)][1].append(subject)
+    
+    return render_to_response('course_catalog/pages/index.html', {'subject_buckets': buckets})
 
 @cache_page(60 * 30)
 def course_detail(request, subject_abbr=None, course_number=None):

--- a/templates/course_catalog/pages/index.html
+++ b/templates/course_catalog/pages/index.html
@@ -14,27 +14,33 @@
 <div class="row">
     <div class="span6">
 
-        {% if subject_list %}
-            <table class="table table-striped table-hover table-condensed">
-                {% for subject in subject_list %}
+        {% if subject_buckets %}
+            {% for bucket in subject_buckets %}
+
+                <p style="font-weight:bold">{{bucket.0}}</p>
+                <table class="table table-striped table-hover table-condensed">
                 
-                    <tr>
+                    {% for subject in bucket.1 %}
                     
-                        <td class="abbreviation">
-                            
-                            {{ subject.abbreviation }} 
-                        </td>
-                        <td class="subject_title">
-                            <a href="{{ subject.get_absolute_url }}">
-                            {{ subject.title }}
-                            </a>
-                        </td>
-                    
-                    </tr>
-                    
-                    
-                {% endfor %}
-            </table>
+                        <tr>
+                        
+                            <td class="abbreviation">
+                                
+                                {{ subject.abbreviation }} 
+                            </td>
+                            <td class="subject_title">
+                                <a href="{{ subject.get_absolute_url }}">
+                                {{ subject.title }}
+                                </a>
+                            </td>
+                        
+                        </tr>
+                        
+                    {% endfor %}
+            
+                </table><br/>
+
+            {% endfor %}
         {% else %}
             <p>No subjects are available.</p>
         {% endif %}


### PR DESCRIPTION
http://qcumber.uservoice.com/forums/181738-general/suggestions/3458050-make-alphabetical-tabs suggests organizing the courses into tabs based on letter.

Work for this feature will be done on the [feature/letter_pages](https://github.com/ChrisCooper/QcumberD/tree/feature/letter_pages) branch.

Possible group splitting algorithm:
http://www.or-exchange.com/questions/4398/dividing-into-roughly-equal-sized-groups-with-a-sorted-list

Possible tab interfaces:

CSS:
- http://css-tricks.com/examples/CSSTabs/radio.php

JS:
- http://phrogz.net/JS/Tabtastic/index.htm
- http://www.barelyfitz.com/projects/tabber/
