### PR TITLE
fix #16, get the career tables to slide up and down

### DIFF
--- a/templates/course_catalog/pages/subject_detail.html
+++ b/templates/course_catalog/pages/subject_detail.html
@@ -37,38 +37,35 @@
                     <li class="well well-small">
             
                         <header>
-                        <a href="#" class="dropdown-header clearfix">
-                            <h3>
-                                {{ career.name }}
-                            </h3>
-                        </a>
+                            <a href="#" class="dropdown-header clearfix">
+                                <h3>
+                                    {{ career.name }}
+                                </h3>
+                            </a>
                         </header>
                 
-                        <table class="table  table-hover table-condensed">
-                            {% for course in courses %}
-                            <tr class="course {% if course.is_empty %} useless {% endif %}">
-                            <a href="{{ course.get_absolute_url }}" class="course-table">
-                            
-                                    <td class="abbreviation">
-                                        {{ subject.abbreviation }} {{ course.number }}
-                                    </td>
-                                    <td class="course_title">
-                                    <a href="{{ course.get_absolute_url }}" class="ununderlineable">
-                                        <span class="underlineable">{{ course.title }}</span>
-                                        {% for season in course.seasons_offered %}
-                                            <span class="season-tag icon-{{ season.name }}">{{ season.name }}</span>
-                                        {% endfor %}
-                                    </a>
-                                    </td>
-
-                                    <td class="units">
-                                        {{ course.units }} units
-                                    </td>
-                        
-                            </a>
-                            </tr>
-                            {% endfor %}
-                        </table>
+                        <div class="table-slide-smoother">
+                            <table class="table  table-hover table-condensed">
+                                {% for course in courses %}
+                                <tr class="course {% if course.is_empty %} useless {% endif %}">
+                                        <td class="abbreviation">
+                                            {{ subject.abbreviation }} {{ course.number }}
+                                        </td>
+                                        <td class="course_title">
+                                        <a href="{{ course.get_absolute_url }}" class="ununderlineable">
+                                            <span class="underlineable">{{ course.title }}</span>
+                                            {% for season in course.seasons_offered %}
+                                                <span class="season-tag icon-{{ season.name }}">{{ season.name }}</span>
+                                            {% endfor %}
+                                        </a>
+                                        </td>
+                                        <td class="units">
+                                            {{ course.units }} units
+                                        </td>
+                                </tr>
+                                {% endfor %}
+                            </table>
+                        </div>
                     </li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
... without some of the overhead I had in the #16 pull request.

Fixed by removing the anchor tag between the `<tr>` and `<td>` tags. You can't have arbitrary tags between those in the dom tree, so webkit decided to move them before the table. That caused the `toggleSlide` to be applied to a misplaced invisible link instead of the table.

I also added a div around the table, because jQuery's `toggleSlide` doesn't look good on tables themselves.
