### PR TITLE
fix unscheduled filter rules

### DIFF
--- a/qcumber/static/js/main.js
+++ b/qcumber/static/js/main.js
@@ -19,7 +19,7 @@ $('.season-filter').click(function() {
         $('.course_list .season-' + season).parents('tr').show();
     } else {
         $('.course_list .course').hide();
-        $('#season-filter .season-filter').filter(function() {
+        $('.season-filter').filter(function() {
             return $(this).is(':checked');
         }).map(function() {
             var season = $(this).attr('name');

--- a/templates/course_catalog/pages/subject_detail.html
+++ b/templates/course_catalog/pages/subject_detail.html
@@ -61,7 +61,7 @@
                                                     </span>
                                                 </span>
                                             {% empty %}
-                                                <span class="season-None"></span>
+                                                <span class="season-Unscheduled"></span>
                                             {% endfor %}
                                         </a>
                                         </td>


### PR DESCRIPTION
... I forgot to update a class to Unscheduled from None, so all the unscheduled courses were disappearing. Should work now, I swear!
