### PR TITLE
Automate the proxying of exam links

### DIFF
--- a/exams/exam_scraper.py
+++ b/exams/exam_scraper.py
@@ -75,7 +75,7 @@ class ExamScraper(object):
 
         exam_attrs = {
                     "year": year,
-                    "pdf_url": "http://library.queensu.ca" + match.string}
+                    "pdf_url": "http://library.queensu.ca.proxy.queensu.ca{0}".format(match.string)}
 
         exam = existing_or_new(Exam, **exam_attrs)
         for course_relation in course_relations:


### PR DESCRIPTION
I did this from the shell last time I think. I left the code around somewhere too... :P
So this should be added to the exam scraper:

http://library.queensu.ca/exambank/9899/anat101.pdf ->
http://library.queensu.ca.proxy.queensu.ca/exambank/9899/anat101.pdf
